### PR TITLE
Chore/update bun setup to v2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,6 @@ runs:
   steps:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
     - name: Install dependencies
       shell: bash
       run: bun install --frozen-lockfile

--- a/tooling/github/setup/action.yml
+++ b/tooling/github/setup/action.yml
@@ -6,8 +6,6 @@ runs:
   steps:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
 
     - shell: bash
       run: bun install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Chore: standardize Bun setup in GitHub composite actions**
> 
> - Upgrade `oven-sh/setup-bun` to `@v2` in `action.yml` and `tooling/github/setup/action.yml`
> - Remove legacy `@v1`/duplicate setup steps and version pinning, keeping a single Bun setup step
> - Retain install/build/run steps using `bun install`, `bun run build`, and `bun dist/main.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de445a78e9d47864d63ef6896ab2ac35015cb58e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->