### PR TITLE
refactor: remove IssueType from types 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,6 @@ export const IMPACT_VALUES = [
   "data_modification",
   "minimal",
 ] as const;
-export const ISSUE_TYPE_VALUES = ["vulnerability", "misconfiguration", "best_practice"] as const;
 export const SECURITY_CATEGORY_VALUES = [
   "injection",
   "authentication",
@@ -38,7 +37,6 @@ export const SECURITY_CATEGORY_VALUES = [
 export type Severity = (typeof SEVERITY_VALUES)[number];
 export type Exploitability = (typeof EXPLOITABILITY_VALUES)[number];
 export type Impact = (typeof IMPACT_VALUES)[number];
-export type IssueType = (typeof ISSUE_TYPE_VALUES)[number];
 export type SecurityCategory = (typeof SECURITY_CATEGORY_VALUES)[number];
 
 // ============================================================================
@@ -84,11 +82,6 @@ const LocationSchema = z
 
 export const ReviewIssueSchema = z.object({
   title: z.string().describe("Concise title for the issue (3-8 words)"),
-  type: z
-    .enum(ISSUE_TYPE_VALUES)
-    .describe(
-      "Type of security issue: vulnerability (exploitable security flaw), misconfiguration (security misconfiguration), best_practice (security best practice recommendation)",
-    ),
   severity: z
     .enum(SEVERITY_VALUES)
     .describe(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies review data model and formatting by dropping `IssueType` and relying solely on severity and optional security metadata.
> 
> - Removes `ISSUE_TYPE_VALUES` and `IssueType` from `src/types.ts`; deletes `type` field from `ReviewIssueSchema`
> - Updates `src/responses/format.ts` to sort issues by severity only and remove type-based ordering/branching
> - Always includes `securityCategory`, `exploitability`, and `impact` in metadata if present (no longer gated by `type`)
> - Cleans up imports and comments accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42aa97d4505390dcdc1afcccec6fb5a98a0f9f75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->