### PR TITLE
refactor: update GitHub Action inputs to unify API key handling

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,8 +20,8 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          provider: openai
+          api-key: ${{ secrets.OPENAI_API_KEY }}
           post-comment-when-no-issues: true
           ignore-patterns: |
             **/*.md

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -19,8 +19,8 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          provider: openai
+          api-key: ${{ secrets.OPENAI_API_KEY }}
           target-branch: main
           ignore-patterns: |
             **/*.md

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A reusable GitHub Action that analyzes code changes and posts security and quali
   - Posts aggregated comments for medium/low/info issues
 - **Push Mode**: Triggers on direct pushes to a specific branch
   - Creates GitHub issues with all findings when security issues are detected
-- **AI-powered code review** using OpenAI (recommended) or Anthropic Claude Opus (provider is automatically inferred from which API key you provide)
+- **AI-powered code review** using OpenAI (recommended) or Anthropic Claude Opus (explicit provider selection)
 - **File ignore patterns** - Exclude files from analysis using glob patterns (similar to `.eslintignore` or `.gitignore`)
 - Written in TypeScript
 
@@ -48,9 +48,8 @@ jobs:
         uses: adriangohjw/saltman@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Provide openai-api-key (recommended) OR anthropic-api-key. If both are provided, OpenAI will be used.
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}  # Recommended: For OpenAI
-          # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}  # Alternative: For Claude Opus (OpenAI is recommended)
+          provider: openai  # Must be either "openai" or "anthropic". OpenAI is recommended.
+          api-key: ${{ secrets.OPENAI_API_KEY }}  # API key for the specified provider
           post-comment-when-no-issues: true  # Optional: set to true to post analysis as PR comment when no issues are detected (defaults to false)
           ignore-patterns: |  # Optional: exclude files from analysis using glob patterns
             **/*.test.ts
@@ -84,9 +83,8 @@ jobs:
         uses: adriangohjw/saltman@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Provide openai-api-key (recommended) OR anthropic-api-key. If both are provided, OpenAI will be used.
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}  # Recommended: For OpenAI
-          # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}  # Alternative: For Claude Opus (OpenAI is recommended)
+          provider: openai  # Must be either "openai" or "anthropic". OpenAI is recommended.
+          api-key: ${{ secrets.OPENAI_API_KEY }}  # API key for the specified provider
           target-branch: main  # Required for push mode: branch to monitor
           ignore-patterns: |  # Optional: exclude files from analysis using glob patterns
             **/*.md
@@ -99,8 +97,8 @@ jobs:
 ### Inputs
 
 - `github-token` (required): GitHub token for API access. Use `${{ secrets.GITHUB_TOKEN }}` for automatic token.
-- `openai-api-key` (required if using OpenAI, **recommended**): OpenAI API key for LLM-powered code review. Store this as a secret in your repository settings (e.g., `OPENAI_API_KEY`). **Recommended over Claude**. If both `openai-api-key` and `anthropic-api-key` are provided, OpenAI will be used.
-- `anthropic-api-key` (required if using Claude): Anthropic API key for Claude Opus code review. Store this as a secret in your repository settings (e.g., `ANTHROPIC_API_KEY`). **Note: OpenAI is recommended over Claude**. If both `openai-api-key` and `anthropic-api-key` are provided, OpenAI will be preferred. The provider is automatically inferred from which API key(s) you provide.
+- `provider` (required): LLM provider to use for code review. Must be either `"openai"` or `"anthropic"`. **OpenAI is recommended** for better performance and reliability.
+- `api-key` (required): API key for the specified LLM provider. Store this as a secret in your repository settings (e.g., `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`).
 - `post-comment-when-no-issues` (optional, PR mode only): Whether to post the analysis as a comment on the PR when no issues are detected. Must be `true` or `false` if specified. Defaults to `false` if not provided (no comment will be posted). **Mutually exclusive with `target-branch`**.
 - `target-branch` (optional, Push mode only): Branch name to monitor for direct pushes. When set and action is triggered on a push event, creates a GitHub issue instead of PR comments. The action will only run when someone pushes directly to this branch. **Mutually exclusive with `post-comment-when-no-issues`**.
 - `ignore-patterns` (optional): Newline-separated list of glob patterns to exclude files from analysis. Similar to `.eslintignore` or `.gitignore` patterns. Files matching any pattern will be skipped during analysis. Examples:

--- a/action.yml
+++ b/action.yml
@@ -7,12 +7,12 @@ inputs:
   github-token:
     description: 'GitHub token for API access'
     required: true
-  openai-api-key:
-    description: 'OpenAI API key for LLM code review (recommended). If both openai-api-key and anthropic-api-key are provided, OpenAI will be used.'
-    required: false
-  anthropic-api-key:
-    description: 'Anthropic API key for LLM code review. Note: OpenAI is recommended over Claude. If both openai-api-key and anthropic-api-key are provided, OpenAI will be used.'
-    required: false
+  provider:
+    description: 'LLM provider to use for code review. Must be either "openai" or "anthropic". OpenAI is recommended.'
+    required: true
+  api-key:
+    description: 'API key for the specified LLM provider.'
+    required: true
   post-comment-when-no-issues:
     description: 'Whether to post the analysis as a comment on the PR when no issues are detected (true/false). Defaults to false if not specified.'
     required: false
@@ -38,8 +38,8 @@ runs:
       run: bun dist/main.js
       env:
         INPUT_GITHUB-TOKEN: ${{ inputs.github-token }}
-        INPUT_OPENAI-API-KEY: ${{ inputs.openai-api-key }}
-        INPUT_ANTHROPIC-API-KEY: ${{ inputs.anthropic-api-key }}
+        INPUT_PROVIDER: ${{ inputs.provider }}
+        INPUT_API-KEY: ${{ inputs.api-key }}
         INPUT_POST-COMMENT-WHEN-NO-ISSUES: ${{ inputs.post-comment-when-no-issues }}
         INPUT_IGNORE-PATTERNS: ${{ inputs.ignore-patterns }}
         INPUT_TARGET-BRANCH: ${{ inputs.target-branch }}

--- a/src/analyzePR.ts
+++ b/src/analyzePR.ts
@@ -57,7 +57,7 @@ const callOpenAI = async (apiKey: string, diff: string): Promise<ParsedReview> =
   return response.output_parsed as ParsedReview;
 };
 
-const callClaude = async (apiKey: string, diff: string): Promise<ParsedReview> => {
+const callAnthropic = async (apiKey: string, diff: string): Promise<ParsedReview> => {
   const anthropic = new Anthropic({
     apiKey: apiKey,
   });
@@ -116,8 +116,8 @@ export const analyzePR = async ({
     core.info(`Using LLM provider: ${provider}`);
     let parsedReview;
     switch (provider) {
-      case "claude":
-        parsedReview = await callClaude(apiKey, diff);
+      case "anthropic":
+        parsedReview = await callAnthropic(apiKey, diff);
         break;
       case "openai":
         parsedReview = await callOpenAI(apiKey, diff);

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,8 @@ async function run(): Promise<void> {
   try {
     // Get inputs
     const inputToken = core.getInput("github-token", { required: true });
-    const inputOpenaiApiKey = core.getInput("openai-api-key");
-    const inputAnthropicApiKey = core.getInput("anthropic-api-key");
+    const inputProvider = core.getInput("provider", { required: true });
+    const inputApiKey = core.getInput("api-key", { required: true });
     const inputPostCommentWhenNoIssues = core.getInput("post-comment-when-no-issues");
     const inputIgnorePatterns = core.getInput("ignore-patterns");
     const inputTargetBranch = core.getInput("target-branch");
@@ -27,8 +27,8 @@ async function run(): Promise<void> {
     const { token, provider, apiKey, postCommentWhenNoIssues, ignorePatterns, targetBranch } =
       validateGithubInputs({
         token: inputToken,
-        openaiApiKey: inputOpenaiApiKey,
-        anthropicApiKey: inputAnthropicApiKey,
+        provider: inputProvider,
+        apiKey: inputApiKey,
         postCommentWhenNoIssues: inputPostCommentWhenNoIssues,
         ignorePatterns: inputIgnorePatterns,
         targetBranch: inputTargetBranch,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Shifts the Action to explicit LLM selection and credentials, simplifying configuration and removing inference logic.
> 
> - Replace `openai-api-key`/`anthropic-api-key` inputs with `provider` ("openai" | "anthropic") and a single `api-key` in `action.yml`; update env wiring (`INPUT_PROVIDER`, `INPUT_API-KEY`)
> - Update validation to require `provider` and `apiKey`, remove key inference, add warning when `provider` is `"anthropic"`; keep mutual exclusivity of `target-branch` vs `post-comment-when-no-issues`
> - Rename provider handling in code: `claude` -> `anthropic`, `callClaude` -> `callAnthropic`, and switch cases accordingly in `src/analyzePR.ts`
> - Adjust `src/main.ts` to read new inputs and pass through to analysis; no behavioral change to PR vs push modes
> - Update example workflows (`test-pr.yml`, `test-push.yml`) and `README.md` to use `provider` + `api-key`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a731d70170718174619072945807ecf10e966d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->