### PR TITLE
(bug) add support for models without structured output capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,32 @@ jobs:
           api-key: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}  # API key for your provider
           base-url: https://api.example.com/v1  # Base URL for your OpenAI-compatible API
           model: gpt-4  # Model name to use (e.g., "gpt-4", "gpt-3.5-turbo", or your custom model name)
+          structured-outputs: false  # Optional: set to false if your provider doesn't support structured outputs (defaults to true)
 ```
 
 **Note:** When using `provider: openai-compatible`, both `base-url` and `model` are required.
+
+**Structured Outputs vs JSON Mode:**
+
+By default, the action uses structured outputs (modern OpenAI-compatible APIs) for more reliable parsing. If your provider doesn't support structured outputs, set `structured-outputs: false` to use JSON mode instead:
+
+```yaml
+# Example with a provider that doesn't support structured outputs
+- name: Run Saltman
+  uses: adriangohjw/saltman@v1
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    provider: openai-compatible
+    api-key: ${{ secrets.YOUR_PROVIDER_API_KEY }}
+    base-url: https://your-provider.com/v1
+    model: your-model-name
+    structured-outputs: false  # Use JSON mode instead of structured outputs
+```
+
+Most modern OpenAI-compatible providers support structured outputs. Only set this to `false` if you encounter errors related to structured output parsing. 
+
+Known providers that do not support structured outputs:
+- Z.ai (e.g. GLM-4.7)
 
 ### Inputs
 
@@ -271,6 +294,7 @@ jobs:
 | `api-key` | ✅ Yes | Both | API key for the specified LLM provider. Store this as a secret in your repository settings (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or your custom provider's API key). |
 | `base-url` | Conditional | Both | Required when `provider` is `"openai-compatible"`. Base URL for your OpenAI-compatible API endpoint (e.g., `https://api.example.com/v1` or `http://localhost:1234/v1`). |
 | `model` | Optional | Both | Model name to use. For OpenAI: `gpt-5.1-codex-mini` (default), `gpt-5.1-codex-max`, or `gpt-5.2-codex`. For Anthropic: `claude-sonnet-4-5`, `claude-haiku-4-5`, or `claude-opus-4-5` (default). Required when `provider` is `"openai-compatible"`. |
+| `structured-outputs` | ❌ No | Both | Whether to use structured outputs (default) or JSON mode for OpenAI-compatible providers. Must be `true` or `false` if specified. Defaults to `true`. Set to `false` if your provider does not support structured outputs (e.g., some older OpenAI-compatible APIs). Using JSON mode may be less reliable than structured outputs. |
 | `post-comment-when-no-issues` | ❌ No | PR only | Whether to post the analysis as a comment on the PR when no issues are detected. Must be `true` or `false` if specified. Defaults to `false`. **Mutually exclusive with `target-branch`**. |
 | `target-branch` | ❌ No | Push only | Branch name to monitor for direct pushes. When set and action is triggered on a push event, creates a GitHub issue instead of PR comments. The action will only run when someone pushes directly to this branch. **Mutually exclusive with `post-comment-when-no-issues`**. |
 | `ping-users` | ❌ No | Both | Space or newline-separated list of GitHub usernames or teams to ping. All items must start with `@`. In PR mode, these are added to PR comment footers. In push mode, these are added to issue footers along with the commit pusher. All mentions are automatically deduplicated. |

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   severity-filter:
     description: 'Newline-separated list of severity levels to include in the review (e.g., "critical\nhigh\nmedium"). Valid values: critical, high, medium, low, info. If unspecified, all severities are shown.'
     required: false
+  structured-outputs:
+    description: 'Whether to use structured outputs (true) or JSON mode (false) for openai-compatible providers. Defaults to true. Use JSON mode if your provider does not support structured outputs.'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -41,13 +44,19 @@ runs:
       uses: oven-sh/setup-bun@v2
     - name: Install dependencies
       shell: bash
-      run: bun install --frozen-lockfile
+      run: |
+        cd "${{ github.action_path }}"
+        bun install --frozen-lockfile
     - name: Build
       shell: bash
-      run: bun run build
+      run: |
+        cd "${{ github.action_path }}"
+        bun run build
     - name: Run action
       shell: bash
-      run: bun dist/main.js
+      run: |
+        cd "${{ github.action_path }}"
+        bun run dist/main.js
       env:
         INPUT_GITHUB-TOKEN: ${{ inputs.github-token }}
         INPUT_PROVIDER: ${{ inputs.provider }}
@@ -59,4 +68,5 @@ runs:
         INPUT_TARGET-BRANCH: ${{ inputs.target-branch }}
         INPUT_PING-USERS: ${{ inputs.ping-users }}
         INPUT_SEVERITY-FILTER: ${{ inputs.severity-filter }}
+        INPUT_STRUCTURED-OUTPUTS: ${{ inputs.structured-outputs }}
 

--- a/src/analyzePR.ts
+++ b/src/analyzePR.ts
@@ -38,7 +38,11 @@ export interface AnalysisResult {
   allIssues: ParsedReview["issues"];
 }
 
-const callOpenAI = async (apiKey: string, model: string, diff: string): Promise<ParsedReview> => {
+const callOpenAI = async (
+  apiKey: string,
+  model: string,
+  diff: string
+): Promise<ParsedReview> => {
   core.info(`📡 Calling OpenAI API with model: ${model}`);
   const openai = new OpenAI({
     apiKey: apiKey,
@@ -64,7 +68,7 @@ const callOpenAI = async (apiKey: string, model: string, diff: string): Promise<
   // Check if output_parsed is null (can happen when model refuses or parsing fails)
   if (response.output_parsed === null) {
     throw new Error(
-      "Model response could not be parsed. The model may have refused to respond or the response format was invalid.",
+      "Model response could not be parsed. The model may have refused to respond or the response format was invalid."
     );
   }
 
@@ -74,7 +78,7 @@ const callOpenAI = async (apiKey: string, model: string, diff: string): Promise<
 const callAnthropic = async (
   apiKey: string,
   model: string,
-  diff: string,
+  diff: string
 ): Promise<ParsedReview> => {
   core.info(`📡 Calling Anthropic API with model: ${model}`);
   const anthropic = new Anthropic({
@@ -96,10 +100,11 @@ const callAnthropic = async (
   });
 
   // Parse the JSON response from the text content
-  const responseText = response.content[0]?.type === "text" ? response.content[0].text : null;
+  const responseText =
+    response.content[0]?.type === "text" ? response.content[0].text : null;
   if (!responseText) {
     throw new Error(
-      "Model response could not be parsed. The model may have refused to respond or the response format was invalid.",
+      "Model response could not be parsed. The model may have refused to respond or the response format was invalid."
     );
   }
 
@@ -112,9 +117,11 @@ const callOpenAICompatibleStructured = async (
   apiKey: string,
   baseUrl: string,
   model: string,
-  diff: string,
+  diff: string
 ): Promise<ParsedReview> => {
-  core.info(`📡 Calling OpenAI-compatible API at ${baseUrl} with model: ${model}`);
+  core.info(
+    `📡 Calling OpenAI-compatible API at ${baseUrl} with model: ${model}`
+  );
   const openaiCompatible = createOpenAICompatible({
     name: "openai-compatible",
     baseURL: baseUrl,
@@ -131,7 +138,7 @@ const callOpenAICompatibleStructured = async (
 
   if (!object) {
     throw new Error(
-      "Model response could not be parsed. The model may have refused to respond or the response format was invalid.",
+      "Model response could not be parsed. The model may have refused to respond or the response format was invalid."
     );
   }
 
@@ -169,7 +176,9 @@ const callOpenAICompatibleNonStructured = async (
     response_format: { type: "json_object" },
   });
 
-  const content = response.choices[0]?.message?.content;
+  const content =
+    response.choices[0]?.message?.content ||
+    (response.choices[0]?.message as any)?.reasoning_content;
   if (!content) {
     throw new Error("Model response was empty or invalid.");
   }
@@ -206,7 +215,9 @@ export const analyzePR = async ({
   structuredOutputs,
 }: AnalyzePRWithContextProps): Promise<AnalysisResult | null> => {
   // Filter out files without patches (binary files, etc.)
-  const filesWithPatches = files.filter((file: FileChange) => file.patch && file.patch.length > 0);
+  const filesWithPatches = files.filter(
+    (file: FileChange) => file.patch && file.patch.length > 0
+  );
 
   // No text-based files to review - return null (no analysis performed)
   if (filesWithPatches.length === 0) {
@@ -217,12 +228,17 @@ export const analyzePR = async ({
     // Convert file changes to a single diff string
     // Include filename so LLM knows which file each diff belongs to
     const diff = filesWithPatches
-      .map((file: FileChange) => `--- a/${file.filename}\n+++ b/${file.filename}\n${file.patch}`)
+      .map(
+        (file: FileChange) =>
+          `--- a/${file.filename}\n+++ b/${file.filename}\n${file.patch}`
+      )
       .join("\n\n");
 
     // Call the appropriate provider
     const modelWithDefault = getModelWithDefault(provider, model);
-    core.info(`🚀 Starting code analysis with ${provider} using model: ${modelWithDefault}`);
+    core.info(
+      `🚀 Starting code analysis with ${provider} using model: ${modelWithDefault}`
+    );
     let parsedReview;
     switch (provider) {
       case "anthropic":
@@ -233,12 +249,22 @@ export const analyzePR = async ({
         break;
       case "openai-compatible":
         if (!baseUrl) {
-          throw new Error('base-url is required when provider is "openai-compatible"');
+          throw new Error(
+            'base-url is required when provider is "openai-compatible"'
+          );
         }
         if (!model) {
-          throw new Error('model is required when provider is "openai-compatible"');
+          throw new Error(
+            'model is required when provider is "openai-compatible"'
+          );
         }
-        parsedReview = await callOpenAICompatible(apiKey, baseUrl, model, diff, structuredOutputs);
+        parsedReview = await callOpenAICompatible(
+          apiKey,
+          baseUrl,
+          model,
+          diff,
+          structuredOutputs
+        );
         break;
       default:
         const _exhaustiveCheck: never = provider;
@@ -246,7 +272,9 @@ export const analyzePR = async ({
     }
 
     // Log successful API response
-    core.info(`✅ Successfully received response from ${provider} model: ${modelWithDefault}`);
+    core.info(
+      `✅ Successfully received response from ${provider} model: ${modelWithDefault}`
+    );
 
     // Log AI response in nicely formatted JSON for debugging
     core.info("=== AI Response (Parsed) ===");
@@ -274,7 +302,8 @@ export const analyzePR = async ({
     }
 
     // Separate issues by severity
-    const { criticalHigh, mediumLowInfo } = separateIssuesBySeverity(filteredIssues);
+    const { criticalHigh, mediumLowInfo } =
+      separateIssuesBySeverity(filteredIssues);
 
     // Generate inline comments for critical/high issues
     const inlineComments = generateInlineComments({
@@ -304,7 +333,8 @@ export const analyzePR = async ({
       allIssues: filteredIssues,
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
     console.error(`${provider} API error: ${errorMessage}`);
 
     // Re-throw the error so CI fails when there's an API error

--- a/src/analyzePR.ts
+++ b/src/analyzePR.ts
@@ -203,6 +203,7 @@ export const analyzePR = async ({
   model,
   pingUsers,
   severityFilter,
+  structuredOutputs,
 }: AnalyzePRWithContextProps): Promise<AnalysisResult | null> => {
   // Filter out files without patches (binary files, etc.)
   const filesWithPatches = files.filter((file: FileChange) => file.patch && file.patch.length > 0);
@@ -237,7 +238,7 @@ export const analyzePR = async ({
         if (!model) {
           throw new Error('model is required when provider is "openai-compatible"');
         }
-        parsedReview = await callOpenAICompatible(apiKey, baseUrl, model, diff);
+        parsedReview = await callOpenAICompatible(apiKey, baseUrl, model, diff, structuredOutputs);
         break;
       default:
         const _exhaustiveCheck: never = provider;

--- a/src/analyzePR.ts
+++ b/src/analyzePR.ts
@@ -15,6 +15,7 @@ import type { GithubInputs } from "./validations/githubInputs";
 import { getModelWithDefault } from "./validations/githubInputs";
 import { estimateMaxTokens } from "./utils/estimateMaxTokens";
 import { filterIssuesBySeverity } from "./filterIssuesBySeverity";
+import { sanitizeReviewResponse } from "./utils/sanitizeReviewResponse";
 
 interface AnalyzePRWithContextProps
   extends AnalyzePRProps,
@@ -184,7 +185,9 @@ const callOpenAICompatibleNonStructured = async (
   }
 
   const parsed = JSON.parse(content);
-  return ReviewResponseSchema.parse(parsed);
+  // Sanitize the response to fix invalid enum values (e.g., securityCategory arrays)
+  const sanitized = sanitizeReviewResponse(parsed);
+  return ReviewResponseSchema.parse(sanitized);
 };
 
 const callOpenAICompatible = async (

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ async function run(): Promise<void> {
     const inputTargetBranch = core.getInput("target-branch");
     const inputPingUsers = core.getInput("ping-users");
     const inputSeverityFilter = core.getInput("severity-filter");
+    const inputStructuredOutputs = core.getInput("structured-outputs");
 
     const {
       token,
@@ -39,6 +40,7 @@ async function run(): Promise<void> {
       targetBranch,
       pingUsers,
       severityFilter,
+      structuredOutputs,
     } = validateGithubInputs({
       token: inputToken,
       provider: inputProvider,
@@ -50,6 +52,7 @@ async function run(): Promise<void> {
       targetBranch: inputTargetBranch,
       pingUsers: inputPingUsers,
       severityFilter: inputSeverityFilter,
+      structuredOutputs: inputStructuredOutputs,
     });
 
     // Initialize GitHub client
@@ -96,6 +99,7 @@ async function run(): Promise<void> {
         model,
         pingUsers,
         severityFilter,
+        structuredOutputs,
       });
 
       // If no analysis was performed (e.g., no text files), skip posting comments
@@ -222,6 +226,7 @@ async function run(): Promise<void> {
         model,
         pingUsers: [pusherUsername, ...(pingUsers ?? [])],
         severityFilter,
+        structuredOutputs,
       });
 
       // If no analysis was performed (e.g., no text files), skip creating issue

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,5 +1,11 @@
-export const getSystemMessage = (): string => {
-  return `You are an expert security-focused code reviewer specializing in VAPT (Vulnerability Assessment and Penetration Testing). 
+interface SystemMessageOptions {
+  includeVerboseJsonInstructions?: boolean;
+}
+
+export const getSystemMessage = (options?: SystemMessageOptions): string => {
+  const { includeVerboseJsonInstructions = false } = options || {};
+
+  const baseInstructions = `You are an expert security-focused code reviewer specializing in VAPT (Vulnerability Assessment and Penetration Testing).
 Your primary responsibility is to identify security vulnerabilities using frameworks like OWASP Top 10 and CVSS scoring principles.
 
 Prioritize security issues above all else. When analyzing code:
@@ -9,6 +15,47 @@ Prioritize security issues above all else. When analyzing code:
 4. Classify severity based on VAPT urgency standards
 
 All issues should be security-related: vulnerabilities (exploitable flaws), misconfigurations (security configuration issues), or best practices (security recommendations).`;
+
+  if (!includeVerboseJsonInstructions) {
+    return baseInstructions;
+  }
+
+  return `${baseInstructions}
+
+CRITICAL OUTPUT FORMAT:
+You must respond with valid JSON containing an "issues" array. Each issue must have these fields with EXACT values from the allowed options:
+
+Required fields with allowed values:
+- title: string (brief title)
+- severity: MUST be one of: "critical", "high", "medium", "low", "info" (pick exactly one)
+- description: string (2-line summary)
+- explanation: string (detailed explanation)
+- location: object with "file" (string) and optionally "startLine" (number)
+- suggestion: string or null (how to fix)
+- securityCategory: MUST be one of: "injection", "authentication", "authorization", "cryptography", "xss", "xxe", "deserialization", "ssrf", "csrf", "idor", "secrets", "config", "logging", "api", "other" (pick exactly one, or omit)
+- exploitability: MUST be one of: "easy", "medium", "hard" (pick exactly one, or omit)
+- impact: MUST be one of: "system_compromise", "data_breach", "privilege_escalation", "information_disclosure", "denial_of_service", "data_modification", "minimal" (pick exactly one, or omit)
+
+IMPORTANT: Pick ONE value from each enum. Do not combine values with | or other characters.
+
+Example valid response:
+{
+  "issues": [
+    {
+      "title": "SQL Injection in login function",
+      "severity": "critical",
+      "description": "User input concatenated into SQL query",
+      "explanation": "The username parameter is directly concatenated...",
+      "location": {"file": "login.js", "startLine": 5},
+      "suggestion": "Use parameterized queries",
+      "securityCategory": "injection",
+      "exploitability": "easy",
+      "impact": "system_compromise"
+    }
+  ]
+}
+
+Return ONLY the JSON object. No markdown, no code blocks, no additional text.`;
 };
 
 export const buildAnalysisPrompt = (diff: string): string => {

--- a/src/utils/sanitizeReviewResponse.ts
+++ b/src/utils/sanitizeReviewResponse.ts
@@ -1,15 +1,61 @@
 import type { ParsedReview } from "../types";
-import { SECURITY_CATEGORY_VALUES } from "../types";
+import {
+  SEVERITY_VALUES,
+  EXPLOITABILITY_VALUES,
+  IMPACT_VALUES,
+  SECURITY_CATEGORY_VALUES,
+} from "../types";
+
+/**
+ * Sanitizes an enum field value by handling arrays and invalid strings.
+ *
+ * @param value - The value to sanitize
+ * @param validValues - Array of valid enum values
+ * @param fieldName - Name of the field (for logging)
+ * @param issueTitle - Title of the issue (for logging)
+ * @param defaultValue - Default value to use if invalid
+ * @returns Sanitized value
+ */
+function sanitizeEnumField<T extends string>(
+  value: any,
+  validValues: readonly T[],
+  fieldName: string,
+  issueTitle: string,
+  defaultValue: T
+): T {
+  // If the value is undefined or null, return as-is (optional fields)
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  // If the value is an array, log warning and return default
+  if (Array.isArray(value)) {
+    console.warn(
+      `⚠️  Invalid ${fieldName} (array) in issue "${issueTitle}": defaulting to "${defaultValue}"`
+    );
+    return defaultValue;
+  }
+
+  // If the value is a string but not in the valid values, default
+  if (typeof value === "string" && !validValues.includes(value as T)) {
+    console.warn(
+      `⚠️  Invalid ${fieldName} "${value}" in issue "${issueTitle}": defaulting to "${defaultValue}"`
+    );
+    return defaultValue;
+  }
+
+  return value as T;
+}
 
 /**
  * Sanitizes a parsed review response from an LLM to fix common validation errors.
  *
  * This handles cases where models without proper structured output support
- * (e.g., GLM-4.7) return invalid values for enum fields like securityCategory.
+ * (e.g., GLM-4.7) return invalid values for enum fields.
  *
- * Known issues:
- * - securityCategory is sometimes an array instead of a string
- * - securityCategory can be an invalid string not in the allowed enum
+ * Known issues handled:
+ * - All enum fields (severity, exploitability, impact, securityCategory) can be arrays
+ * - All enum fields can be invalid strings not in the allowed enum
  *
  * @param parsed - The parsed review response from the LLM
  * @returns Sanitized review response with valid enum values
@@ -22,29 +68,53 @@ export function sanitizeReviewResponse(parsed: any): ParsedReview {
   return {
     ...parsed,
     issues: parsed.issues.map((issue: any) => {
-      // Fix securityCategory if it's invalid
-      if (issue.securityCategory !== undefined && issue.securityCategory !== null) {
-        // If securityCategory is an array, convert to "other"
-        if (Array.isArray(issue.securityCategory)) {
-          console.warn(
-            `⚠️  Invalid securityCategory (array) in issue "${issue.title}": defaulting to "other"`
-          );
-          return { ...issue, securityCategory: "other" };
-        }
+      const sanitizedIssue = { ...issue };
 
-        // If securityCategory is an invalid string, default to "other"
-        if (
-          typeof issue.securityCategory === "string" &&
-          !SECURITY_CATEGORY_VALUES.includes(issue.securityCategory as any)
-        ) {
-          console.warn(
-            `⚠️  Invalid securityCategory "${issue.securityCategory}" in issue "${issue.title}": defaulting to "other"`
-          );
-          return { ...issue, securityCategory: "other" };
-        }
+      // Sanitize severity (required field)
+      if (sanitizedIssue.severity !== undefined && sanitizedIssue.severity !== null) {
+        sanitizedIssue.severity = sanitizeEnumField(
+          sanitizedIssue.severity,
+          SEVERITY_VALUES,
+          "severity",
+          issue.title,
+          "medium" // Default severity
+        );
       }
 
-      return issue;
+      // Sanitize exploitability (optional field)
+      if (sanitizedIssue.exploitability !== undefined && sanitizedIssue.exploitability !== null) {
+        sanitizedIssue.exploitability = sanitizeEnumField(
+          sanitizedIssue.exploitability,
+          EXPLOITABILITY_VALUES,
+          "exploitability",
+          issue.title,
+          "medium" // Default exploitability
+        );
+      }
+
+      // Sanitize impact (optional field)
+      if (sanitizedIssue.impact !== undefined && sanitizedIssue.impact !== null) {
+        sanitizedIssue.impact = sanitizeEnumField(
+          sanitizedIssue.impact,
+          IMPACT_VALUES,
+          "impact",
+          issue.title,
+          "minimal" // Default impact
+        );
+      }
+
+      // Sanitize securityCategory (optional field)
+      if (sanitizedIssue.securityCategory !== undefined && sanitizedIssue.securityCategory !== null) {
+        sanitizedIssue.securityCategory = sanitizeEnumField(
+          sanitizedIssue.securityCategory,
+          SECURITY_CATEGORY_VALUES,
+          "securityCategory",
+          issue.title,
+          "other" // Default security category
+        );
+      }
+
+      return sanitizedIssue;
     }),
   };
 }

--- a/src/utils/sanitizeReviewResponse.ts
+++ b/src/utils/sanitizeReviewResponse.ts
@@ -1,0 +1,50 @@
+import type { ParsedReview } from "../types";
+import { SECURITY_CATEGORY_VALUES } from "../types";
+
+/**
+ * Sanitizes a parsed review response from an LLM to fix common validation errors.
+ *
+ * This handles cases where models without proper structured output support
+ * (e.g., GLM-4.7) return invalid values for enum fields like securityCategory.
+ *
+ * Known issues:
+ * - securityCategory is sometimes an array instead of a string
+ * - securityCategory can be an invalid string not in the allowed enum
+ *
+ * @param parsed - The parsed review response from the LLM
+ * @returns Sanitized review response with valid enum values
+ */
+export function sanitizeReviewResponse(parsed: any): ParsedReview {
+  if (!parsed || !parsed.issues || !Array.isArray(parsed.issues)) {
+    return parsed;
+  }
+
+  return {
+    ...parsed,
+    issues: parsed.issues.map((issue: any) => {
+      // Fix securityCategory if it's invalid
+      if (issue.securityCategory !== undefined && issue.securityCategory !== null) {
+        // If securityCategory is an array, convert to "other"
+        if (Array.isArray(issue.securityCategory)) {
+          console.warn(
+            `⚠️  Invalid securityCategory (array) in issue "${issue.title}": defaulting to "other"`
+          );
+          return { ...issue, securityCategory: "other" };
+        }
+
+        // If securityCategory is an invalid string, default to "other"
+        if (
+          typeof issue.securityCategory === "string" &&
+          !SECURITY_CATEGORY_VALUES.includes(issue.securityCategory as any)
+        ) {
+          console.warn(
+            `⚠️  Invalid securityCategory "${issue.securityCategory}" in issue "${issue.title}": defaulting to "other"`
+          );
+          return { ...issue, securityCategory: "other" };
+        }
+      }
+
+      return issue;
+    }),
+  };
+}

--- a/src/validations/githubInputs.ts
+++ b/src/validations/githubInputs.ts
@@ -44,6 +44,17 @@ const GithubInputsSchema = z
         if (val === undefined || val === "") return undefined;
         return val === "true";
       }),
+    structuredOutputs: z
+      .string()
+      .optional()
+      .refine(
+        (val) => val === undefined || val === "" || val === "true" || val === "false",
+        "structured-outputs must be 'true' or 'false' if specified",
+      )
+      .transform((val) => {
+        if (val === undefined || val === "") return true; // Default to true
+        return val === "true";
+      }),
     targetBranch: z
       .string()
       .optional()


### PR DESCRIPTION
  ### Summary

  Fixes critical build issues and extends compatibility to support models without structured output capabilities. 

Model in Question: Z.ai's GLM

  ###  What Changed

#### Build Fixes
  - Fixed bun command execution by prepending with cd "${{ github.action_path }}" to prevent commands from running at repository root
  - Added explicit build step to ensure dist/main.js is available before the "Run action" step

#### Model Compatibility
  - Added fallback path for models that don't support structured output (e.g., GLM-4-7)
  - When structuredOutputs: false, the action now uses the native OpenAI SDK with JSON mode instead of structured outputs
  - Requires additional verbose JSON formatting instructions in prompts to ensure proper response parsing

   ###  Testing

  - Tested with GLM models to verify the non-structured output path works correctly.
  - Note: Happy to provide a testing GLM token, ping me!
  - Please test with other models (im too poor for other models hehe) 